### PR TITLE
Shorten test version url

### DIFF
--- a/cloudbuild_test.yaml
+++ b/cloudbuild_test.yaml
@@ -49,6 +49,6 @@ steps:
 
   - name: "gcr.io/cloud-builders/gcloud"
     id: Deploy service for testing
-    args: [ "app", "deploy", "--version", "pull-request-number-$_PR_NUMBER", "--no-promote" ]
+    args: [ "app", "deploy", "--version", "pr-no-$_PR_NUMBER", "--no-promote" ]
     timeout: "1600s"
 


### PR DESCRIPTION
SSL certificate breaks as it was longer than 63 chars. 