### PR TITLE
Bugfix config

### DIFF
--- a/app/mover.py
+++ b/app/mover.py
@@ -1,24 +1,27 @@
 from copy import deepcopy
-from typing import Dict
+from typing import Dict, Tuple
 
 import pysftp
-from flask import Blueprint, current_app, request
+from flask import Blueprint, Flask, current_app, request
 from paramiko import SSHException
 
 from models import Instrument, ProcessorEvent
 from pkg.config import Config
 from pkg.google_storage import init_google_storage
-from pkg.sftp import SFTP
+from pkg.sftp import SFTP, SFTPConfig
 from util.service_logging import log
 
 mover = Blueprint("batch", __name__, url_prefix="/")
 
 
+def config_loader(app: Flask) -> Tuple[Config, SFTPConfig]:
+    return deepcopy(app.nisra_config), deepcopy(app.sftp_config)
+
+
 @mover.route("/")
 def main():
     survey_source_path = request.args.get("survey_source_path")
-    config = deepcopy(current_app.nisra_config)
-    sftp_config = deepcopy(current_app.sftp_config)
+    config, sftp_config = config_loader(current_app)
     if survey_source_path:
         sftp_config.survey_source_path = survey_source_path
     google_storage = init_google_storage(config)

--- a/app/mover.py
+++ b/app/mover.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import Dict
 
 import pysftp
@@ -16,8 +17,8 @@ mover = Blueprint("batch", __name__, url_prefix="/")
 @mover.route("/")
 def main():
     survey_source_path = request.args.get("survey_source_path")
-    config = current_app.nisra_config
-    sftp_config = current_app.sftp_config
+    config = deepcopy(current_app.nisra_config)
+    sftp_config = deepcopy(current_app.sftp_config)
     if survey_source_path:
         sftp_config.survey_source_path = survey_source_path
     google_storage = init_google_storage(config)

--- a/tests/app/test_mover.py
+++ b/tests/app/test_mover.py
@@ -1,0 +1,16 @@
+from flask import Flask
+
+from app.mover import config_loader
+
+
+def test_config_loader_immutability(config, sftp_config):
+    test_app = Flask("test_app")
+    test_app.nisra_config = config
+    test_app.sftp_config = sftp_config
+    nisra_config, actual_sftp_config = config_loader(test_app)
+    assert nisra_config.bucket_name == "env_var_not_set"
+    assert actual_sftp_config.survey_source_path == "./ONS/OPN"
+    test_app.nisra_config.bucket_name = "foobar"
+    test_app.sftp_config.survey_source_path = "break_this"
+    assert nisra_config.bucket_name == "env_var_not_set"
+    assert actual_sftp_config.survey_source_path == "./ONS/OPN"


### PR DESCRIPTION
We noticed quite a few errors come out of the case mover in pre-prod. This is basically a race condition because our SFTP config (including survey_source_path) is stored globally on the app.

With the way that we have changed our triggers to pass in the survey_source_path on the URL, we want to make sure we don't have a mutable global variable for this config, as it makes things go badly wrong.

A quick fix is to make sure we load the config in a safer way, longer-term we could look at changing how we load/ pass this config around.