### PR TITLE
fix: Don't exit(1) when handling exceptions at the top level

### DIFF
--- a/main.py
+++ b/main.py
@@ -92,7 +92,6 @@ def do_trigger(event, _context):
                 )
     except Exception as error:
         logging.error(f"{error.__class__.__name__}: {error}", exc_info=True)
-        exit(1)
 
 
 def processor(*args, **kwargs):
@@ -146,7 +145,6 @@ def do_processor(event, _context):
             )
     except Exception as error:
         logging.error(f"{error.__class__.__name__}: {error}", exc_info=True)
-        exit(1)
 
 
 def nisra_changes_checker(_event, _context):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,17 +1,7 @@
 import logging
 from unittest import mock
 
-import pytest
-
 from main import do_processor, do_trigger
-
-
-@mock.patch("main.TriggerEvent.from_json", side_effect=Exception("Kaboom"))
-def test_do_trigger_exits_with_1_when_an_exception_is_raised(_from_json):
-    with pytest.raises(SystemExit) as e:
-        do_trigger(dict(data=""), {})
-
-    assert e.value.code == 1
 
 
 @mock.patch("main.TriggerEvent.from_json")
@@ -21,22 +11,13 @@ def test_do_trigger_logs_error_when_exception_is_raised(from_json, caplog):
     from_json.side_effect = original_exception
 
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(SystemExit):
-            do_trigger(dict(data=""), {})
+        do_trigger(dict(data=""), {})
 
     errors = [entry for entry in caplog.records if entry.levelno == logging.ERROR]
-    assert len(errors) is 1
+    assert len(errors) == 1
     error = errors[0]
     assert error.message == "Exception: Kaboom"
     assert error.exc_info[1] == original_exception
-
-
-@mock.patch("main.Config.from_env", side_effect=Exception("Kaboom"))
-def test_do_processor_exits_with_1_when_an_exception_is_raised(_from_env):
-    with pytest.raises(SystemExit) as e:
-        do_processor(dict(data=""), {})
-
-    assert e.value.code == 1
 
 
 @mock.patch("main.Config.from_env")
@@ -46,11 +27,10 @@ def test_do_processor_logs_error_when_exception_is_raised(from_env, caplog):
     from_env.side_effect = original_exception
 
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(SystemExit):
-            do_processor(dict(data=""), {})
+        do_processor(dict(data=""), {})
 
     errors = [entry for entry in caplog.records if entry.levelno == logging.ERROR]
-    assert len(errors) is 1
+    assert len(errors) == 1
     error = errors[0]
     assert error.message == "Exception: Kaboom"
     assert error.exc_info[1] == original_exception


### PR DESCRIPTION
The ERROR log raises an alert, if we exit(1) a CRITICAL is also alerted which is unncessary.

Refs: BLAIS5-3490
